### PR TITLE
feat: add directory scanning

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	ImageName            string
 	LocalImage           bool
 	FilePath             string
+	DirPath              string
 	Output               string
 	Format               string
 	IgnoreMap            map[string]struct{}

--- a/pkg/assessor/manifest/manifest.go
+++ b/pkg/assessor/manifest/manifest.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/Portshift/dockle/pkg/log"
-
 	"github.com/Portshift/dockle/pkg/types"
 )
 
@@ -23,7 +22,11 @@ var (
 )
 
 func (a ManifestAssessor) Assess(imageData *types.ImageData) (assesses []*types.Assessment, err error) {
-	log.Logger.Debug("Scan start : check config")
+	log.Logger.Debug("Start scan : check config")
+	if imageData.Image == nil {
+		return nil, errors.New("image is nil, ManifestAssessor is skipped")
+	}
+
 	if imageData.Metadata.RawConfig == nil {
 		return nil, errors.New("config json file doesn't exist")
 	}

--- a/pkg/run.go
+++ b/pkg/run.go
@@ -68,7 +68,12 @@ func run(ctx context.Context) (ret types.AssessmentMap, err error) {
 	scanner.AddAcceptanceExtensions(config.Conf.AcceptanceExtensions)
 	log.Logger.Debug("Start assessments...")
 
-	assessments, err := scanner.ScanImage(ctx, config.Conf)
+	var assessments []*types.Assessment
+	if config.Conf.DirPath != "" {
+		assessments, err = scanner.ScanDir(ctx, config.Conf)
+	} else {
+		assessments, err = scanner.ScanImage(ctx, config.Conf)
+	}
 
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {

--- a/pkg/types/imagedata.go
+++ b/pkg/types/imagedata.go
@@ -24,6 +24,14 @@ type FileData struct {
 type FilterFunc func(filePath string, fileMode os.FileMode) (bool, error)
 
 func (f *FileData) ReadContent(img *image.Image) ([]byte, error) {
+	if img == nil {
+		content, err := os.ReadFile(string(f.RealPath))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read content of %s: %w", f.RealPath, err)
+		}
+		return content, nil
+	}
+
 	contentReader, err := img.OpenPathFromSquash(f.RealPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %s: %w", f.RealPath, err)


### PR DESCRIPTION
This PR enables the use of a directory path as input to run a scan on it while preserving all existing behavior.
Most of the assessors use the extracted file data anyway, only the manifest assessor needs to be skipped.

This is to ensure better operability with VMClarity, which does the file extraction step before running the scanners.