### PR TITLE
feat: introduce RunWithContext function

### DIFF
--- a/pkg/run.go
+++ b/pkg/run.go
@@ -49,6 +49,12 @@ func RunFromConfig(conf *config.Config) (types.AssessmentMap, error) {
 	return run(ctx)
 }
 
+func RunWithContext(ctx context.Context, conf *config.Config) (types.AssessmentMap, error) {
+	config.Conf = *conf
+
+	return run(ctx)
+}
+
 func run(ctx context.Context) (ret types.AssessmentMap, err error) {
 	quiet := config.Conf.Quiet
 	debug := config.Conf.Debug


### PR DESCRIPTION
This PR allows to pass a context to Dockle when it is used as a library, without breaking the existing API.

It allows timeouts/cancellations to be handled properly in VMClarity.